### PR TITLE
remove breaking /bin/ path specification

### DIFF
--- a/src/wpaperd.rs
+++ b/src/wpaperd.rs
@@ -14,7 +14,7 @@ pub struct Wpaperd {
 impl Wpaperd {
     pub fn new(initial_path: String, config_hash: String) -> Result<Self, String> {
         // Check if wpaperd is available
-        match process::Command::new("/bin/which")
+        match process::Command::new("which")
             .arg("wpaperd")
             .stdout(process::Stdio::null())
             .stderr(process::Stdio::null())


### PR DESCRIPTION
specifying the path `/bin/` here is unnecessary and breaks unconventional systems ( like nixos )
e.g.. `/bin/which` does not exist, but `which` is within my path.

if you'll merge this pr I'll be making a PR with nixpkgs for the nix package I've made for this project :)