### PR TITLE
Fix hyprpaper integration for v0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 - Support for various wallpaper setters
   - [`wpaperd`](https://github.com/danyspin97/wpaperd)
   - [`swaybg`](https://github.com/swaywm/swaybg)
-  - [`hyprpaper`](https://github.com/hyprwm/hyprpaper)
+  - [`hyprpaper`](https://github.com/hyprwm/hyprpaper) (requires v0.8.0+)
 - Configuration generation for lockers
   - [`swaylock`](https://github.com/swaywm/swaylock)
   - [`hyprlock`](https://github.com/hyprwm/hyprlock)

--- a/src/integrations/hyprpaper.rs
+++ b/src/integrations/hyprpaper.rs
@@ -1,93 +1,26 @@
 use std::collections::HashMap;
-use std::env;
-use std::io::prelude::*;
-use std::os::unix::net::UnixStream;
-use std::thread;
-use std::time::Duration;
+use std::process::Command;
 
 pub struct Hyprpaper;
 impl Hyprpaper {
-    /// Generate and push appropriate socket commands to hyprpaper given new input wallpapers
+    /// Generate and push appropriate commands to hyprpaper via hyprctl given new input wallpapers
     pub fn push(wallpapers: &HashMap<String, String>) -> Result<(), String> {
-        // find socket base with fallback
-        let socket_base: String;
-        if let Ok(xdg_dir) = env::var("XDG_RUNTIME_DIR") {
-            socket_base = xdg_dir;
-        } else if let Ok(uid) = env::var("UID") {
-            socket_base = format!("/run/user/{}", uid);
-        } else {
-            return Err("hyprpaper: no valid socket path found".to_string());
-        }
+        for (monitor, path) in wallpapers {
+            let output = Command::new("hyprctl")
+                .args(["hyprpaper", "wallpaper", &format!("{},{}", monitor, path)])
+                .output()
+                .map_err(|e| format!("hyprpaper: failed to execute hyprctl: {}", e))?;
 
-        // set target socket with fallback
-        let target_socket: String;
-        if let Ok(instance_id) = env::var("HYPRLAND_INSTANCE_SIGNATURE") {
-            target_socket = format!("{}/hypr/{}/.hyprpaper.sock", socket_base, instance_id)
-        } else {
-            target_socket = format!("{}/hypr/.hyprpaper.sock", socket_base)
-        }
-
-        // block till we can connect or met retry limit
-        for _ in 0..40 {
-            match UnixStream::connect(&target_socket) {
-                Ok(mut socket) => {
-                    // unload all first and check for success
-                    let mut buffer = [0; 1024];
-                    socket
-                        .write_all(b"unload all")
-                        .map_err(|err| format!("hyprpaper: {}", err))?;
-                    socket
-                        .read(&mut buffer)
-                        .map_err(|err| format!("hyprpaper: {}", err))?;
-                    if !String::from_utf8_lossy(&buffer)
-                        .to_string()
-                        .to_lowercase()
-                        .contains("ok")
-                    {
-                        return Err("hyprpaper: unload failed".to_string());
-                    }
-
-                    // execute call for every monitor wallpaper
-                    for paper in wallpapers {
-                        // preload wallpaper and check for success
-                        socket
-                            .write_all(format!("preload {}", paper.1).as_bytes())
-                            .map_err(|err| format!("hyprpaper: {}", err))?;
-                        socket
-                            .read(&mut buffer)
-                            .map_err(|err| format!("hyprpaper: {}", err))?;
-                        if !String::from_utf8_lossy(&buffer)
-                            .to_string()
-                            .to_lowercase()
-                            .contains("ok")
-                        {
-                            return Err("hyprpaper: preload failed".to_string());
-                        }
-
-                        // set wallpaper and check for success
-                        socket
-                            .write_all(format!("wallpaper {},{}", paper.0, paper.1).as_bytes())
-                            .map_err(|err| format!("hyprpaper: {}", err))?;
-                        socket
-                            .read(&mut buffer)
-                            .map_err(|err| format!("hyprpaper: {}", err))?;
-                        if !String::from_utf8_lossy(&buffer)
-                            .to_string()
-                            .to_lowercase()
-                            .contains("ok")
-                        {
-                            return Err("hyprpaper: set failed".to_string());
-                        }
-                    }
-
-                    return Ok(());
-                }
-                Err(_) => {
-                    thread::sleep(Duration::from_millis(250));
-                }
+            if !output.status.success() {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                return Err(format!(
+                    "hyprpaper: failed to set wallpaper for {}: {}",
+                    monitor,
+                    stderr.trim()
+                ));
             }
         }
 
-        Err("hyprpaper: connection timeout reached".to_string())
+        Ok(())
     }
 }


### PR DESCRIPTION
## Basic Requirements

- [ x ] I have added documentation if necessary (in README.md)
- [ x ] I have tested my code
- [ x ] I have synced my branch with master

## Describe your Pull Request, what does it fix or add?
This PR updates the hyprpaper integration to work with v0.8.0, which introduced breaking changes through a complete rewrite - the implementation now uses the simpler CLI interface instead of the deprecated IPC interface.

## Is there anything else worth mentioning? (side effects, possible bugs, etc.)
- Requires hyprpaper v0.8.0 or newer when using with hyprpaper backend (not backward compatible)
- Tested with hyprpaper v0.8.1 on nixos using flake.nix
